### PR TITLE
Fix next_change computation

### DIFF
--- a/humanized_opening_hours/main.py
+++ b/humanized_opening_hours/main.py
@@ -544,7 +544,7 @@ class OHParser:
                     end_time
                 )
         elif (
-            _recursion_level > 1 and
+            _recursion_level > 0 and
             beginning_time.time() != datetime.time.min
         ):
             return None

--- a/humanized_opening_hours/temporal_objects.py
+++ b/humanized_opening_hours/temporal_objects.py
@@ -573,7 +573,7 @@ class MonthDayDate:
             last_monthday = datetime.date(
                 self.year or dt.year,
                 self.month,
-                self.safe_monthrange(self.year or dt.year, dt.month)[1]
+                self.safe_monthrange(self.year or dt.year, self.month)[1]
             )
             dates = []
             for i in range((last_monthday - first_monthday).days + 1):

--- a/tests.py
+++ b/tests.py
@@ -819,7 +819,10 @@ class TestGlobal(unittest.TestCase):
         dt = datetime.datetime(2018, 1, 5, 10, 0)
         self.assertEqual(
             oh.next_change(dt),
-            datetime.datetime(2018, 1, 6, 8, 0)
+            datetime.datetime.combine(
+                datetime.date(2018, 1, 5),
+                datetime.time.max
+            )
         )
         dt = datetime.datetime(2018, 1, 7, 10, 0)
         self.assertEqual(

--- a/tests.py
+++ b/tests.py
@@ -826,6 +826,42 @@ class TestGlobal(unittest.TestCase):
             oh.next_change(dt),
             datetime.datetime(2018, 1, 8, 0, 0)
         )
+
+    def test_11(self):
+        field = "Jan-Feb 10:00-20:00"
+        oh = OHParser(field)
+
+        dt = datetime.datetime(2018, 1, 1, 12, 0)
+        self.assertTrue(oh.is_open(dt))
+        dt = datetime.datetime(2018, 1, 1, 22, 0)
+        self.assertFalse(oh.is_open(dt))
+        dt = datetime.datetime(2018, 3, 1, 12, 0)
+        self.assertFalse(oh.is_open(dt))
+        # Next change
+        dt = datetime.datetime(2018, 1, 1, 12, 0)
+        self.assertEqual(
+            oh.next_change(dt),
+            datetime.datetime.combine(
+                datetime.date(2018, 1, 1),
+                datetime.time(20, 0)
+            )
+        )
+        dt = datetime.datetime(2018, 1, 1, 22, 0)
+        self.assertEqual(
+            oh.next_change(dt),
+            datetime.datetime.combine(
+                datetime.date(2018, 1, 2),
+                datetime.time(10, 0)
+            )
+        )
+        dt = datetime.datetime(2018, 6, 1, 12, 0)
+        self.assertEqual(
+            oh.next_change(dt),
+            datetime.datetime.combine(
+                datetime.date(2019, 1, 1),
+                datetime.time(10, 0)
+            )
+        )
     
     def test_closed(self):
         oh = OHParser("24/7; Su off")


### PR DESCRIPTION
* In MonthDayDate `dt.month` should not be used to compute `last_month_day`.  
It also raises an exception when `dt.month` has more days than `self.month`.
I added a test to cover that case. 

* Another minor fix to handle next_change time at midnight. The test case was incorrect.