### PR TITLE
Fix opening_periods_between for periods not overlapping with dt1 and dt2

### DIFF
--- a/humanized_opening_hours/main.py
+++ b/humanized_opening_hours/main.py
@@ -825,6 +825,11 @@ class OHParser:
                 period[0] < dt2 < period[1]
             ):
                 output_periods.append((period[0], dt2))
+            elif (
+                isinstance(dt1, datetime.datetime) and period[1] <= dt1 or
+                isinstance(dt2, datetime.datetime) and dt2 <= period[0]
+            ):
+                continue
             else:
                 output_periods.append(period)
         if merge:

--- a/tests.py
+++ b/tests.py
@@ -1689,6 +1689,117 @@ class TestFunctions(unittest.TestCase):
         )
 
 
+class TestOpeningPeriodsBetween(unittest.TestCase):
+    def test_simple(self):
+        oh = OHParser("09:00-19:00")
+        # completely before
+        self.assertEqual(
+            oh.opening_periods_between(
+                datetime.datetime(2019, 1, 20, 23),
+                datetime.datetime(2019, 1, 21, 1),
+            ),
+            [],
+        )
+        self.assertEqual(
+            oh.opening_periods_between(
+                datetime.datetime(2019, 1, 21, 5),
+                datetime.datetime(2019, 1, 21, 7),
+            ),
+            [],
+        )
+        self.assertEqual(
+            oh.opening_periods_between(
+                datetime.datetime(2019, 1, 21, 7),
+                datetime.datetime(2019, 1, 21, 9),
+            ),
+            [],
+        )
+        # partly before
+        self.assertEqual(
+            oh.opening_periods_between(
+                datetime.datetime(2019, 1, 21, 8),
+                datetime.datetime(2019, 1, 21, 10),
+            ),
+            [
+                (datetime.datetime(2019, 1, 21, 9), datetime.datetime(2019, 1, 21, 10)),
+            ],
+        )
+        # between
+        self.assertEqual(
+            oh.opening_periods_between(
+                datetime.datetime(2019, 1, 21, 9),
+                datetime.datetime(2019, 1, 21, 11),
+            ),
+            [
+                (datetime.datetime(2019, 1, 21, 9), datetime.datetime(2019, 1, 21, 11)),
+            ],
+        )
+        self.assertEqual(
+            oh.opening_periods_between(
+                datetime.datetime(2019, 1, 21, 17),
+                datetime.datetime(2019, 1, 21, 19),
+            ),
+            [
+                (datetime.datetime(2019, 1, 21, 17), datetime.datetime(2019, 1, 21, 19)),
+            ],
+        )
+        # partly after
+        self.assertEqual(
+            oh.opening_periods_between(
+                datetime.datetime(2019, 1, 21, 18),
+                datetime.datetime(2019, 1, 21, 20),
+            ),
+            [
+                (datetime.datetime(2019, 1, 21, 18), datetime.datetime(2019, 1, 21, 19)),
+            ],
+        )
+        # completely after
+        self.assertEqual(
+            oh.opening_periods_between(
+                datetime.datetime(2019, 1, 21, 19),
+                datetime.datetime(2019, 1, 21, 21),
+            ),
+            [],
+        )
+        self.assertEqual(
+            oh.opening_periods_between(
+                datetime.datetime(2019, 1, 21, 21),
+                datetime.datetime(2019, 1, 21, 23),
+            ),
+            [],
+        )
+        self.assertEqual(
+            oh.opening_periods_between(
+                datetime.datetime(2019, 1, 21, 23),
+                datetime.datetime(2019, 1, 22, 1),
+            ),
+            [],
+        )
+
+    def test_complex(self):
+        oh = OHParser("09:00-11:00,13:00-15:00,17:00-19:00")
+        self.assertEqual(
+            oh.opening_periods_between(
+                datetime.datetime(2019, 1, 21, 10),
+                datetime.datetime(2019, 1, 21, 18),
+            ),
+            [
+                (datetime.datetime(2019, 1, 21, 10), datetime.datetime(2019, 1, 21, 11)),
+                (datetime.datetime(2019, 1, 21, 13), datetime.datetime(2019, 1, 21, 15)),
+                (datetime.datetime(2019, 1, 21, 17), datetime.datetime(2019, 1, 21, 18)),
+            ],
+        )
+        self.assertEqual(
+            oh.opening_periods_between(
+                datetime.datetime(2019, 1, 21, 11),
+                datetime.datetime(2019, 1, 21, 17),
+            ),
+            [
+                (datetime.datetime(2019, 1, 21, 13), datetime.datetime(2019, 1, 21, 15)),
+            ],
+        )
+
+
 if __name__ == '__main__':
     unittest.main()
     exit(0)


### PR DESCRIPTION
Currently, `opening_periods_between` returns periods that are before dt1 or after dt2. This pull request will fix this.

I have also added some tests for `opening_periods_between`.