### PR TITLE
Fix OverflowError when no rule exists in the future

### DIFF
--- a/humanized_opening_hours/main.py
+++ b/humanized_opening_hours/main.py
@@ -504,6 +504,12 @@ class OHParser:
                     break
                 elif _recursion_level > 0:
                     return (None, None)
+                elif i == max(max_recursion, 1000):
+                    # Allow at least 1000 iterations, and avoid date overflow
+                    raise NextChangeRecursionError(
+                        "No matching rule found after {} iterations".format(i),
+                        dt
+                    )
                 i += 1
             new_dt = datetime.datetime.combine(
                 dt.date() + datetime.timedelta(i),

--- a/tests.py
+++ b/tests.py
@@ -965,6 +965,9 @@ class TestGlobal(unittest.TestCase):
         oh = OHParser("2019 Oct- 2020 Feb 07:30-19:30")
         self.assertFalse(oh.is_open(datetime.datetime(2019, 1, 1, 12, 30)))
 
+        with self.assertRaises(NextChangeRecursionError):
+            oh.next_change(datetime.datetime(2020,6,1))
+
 class TestSolarHours(unittest.TestCase):
     maxDiff = None
     


### PR DESCRIPTION
opening_hours values such as `2018 Jul 02- 2018 Sep 02 Mo-Su 08:00-20:00` (with limited timespan) cause `next_change` to raise an OverflowError.

This PR suggests to limit the number of iterations to find a date when a "current rule" applies.